### PR TITLE
chore: Update GoReleaser Action config

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,5 +15,8 @@ jobs:
           go-version: 1.13
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build executable binary
-        run: make build
+      - name: Release snapshot
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          verson: v0.138.0
+          args: release --snapshot --skip-publish --rm-dist

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,11 +14,12 @@ jobs:
           go-version: 1.14
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Unshallow # This step is required for the changelog to work correctly
-        run: git fetch --prune --unshallow
-      - name: Release
-        uses: goreleaser/goreleaser-action@v1
         with:
+          fetch-depth: 0
+      - name: Release
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: v0.138.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Starboard Octant Plugin
 
 [![GitHub Release][release-img]][release]
-[![Build Actions][build-action-img]][build-action]
+[![GitHub Build Actions][build-action-img]][actions]
+[![GitHub Release Action][release-action-img]][actions]
 [![License][license-img]][license]
 
 > This is an [Octant][octant] plugin for [Starboard][starboard] which provides visibility into vulnerability assessment
@@ -194,7 +195,8 @@ This repository is available under the [Apache License 2.0][license].
 [release-img]: https://img.shields.io/github/release/aquasecurity/starboard-octant-plugin.svg
 [release]: https://github.com/aquasecurity/starboard-octant-plugin/releases
 [build-action-img]: https://github.com/aquasecurity/starboard-octant-plugin/workflows/build/badge.svg
-[build-action]: https://github.com/aquasecurity/starboard-octant-plugin/actions
+[release-action-img]: https://github.com/aquasecurity/starboard-octant-plugin/workflows/release/badge.svg
+[actions]: https://github.com/aquasecurity/starboard-octant-plugin/actions
 [license-img]: https://img.shields.io/github/license/aquasecurity/starboard-octant-plugin.svg
 [license]: https://github.com/aquasecurity/starboard-octant-plugin/blob/master/LICENSE
 


### PR DESCRIPTION
The latest release of GoReleaser has broken the way we auto generate changes log. Therefore:

- I pinned to GoReleaser v0.138.0
- Updated GitHub Action config

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>