### PR TITLE
feat: Check if Starboard CRDs exist before rendering UI components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ OCTANT_PLUGINS_DIR = ~/.config/octant/plugins
 build:
 	go build -o bin/starboard-octant-plugin cmd/starboard-octant-plugin/main.go
 
-deploy: build
+install: build
 	mkdir -p $(OCTANT_PLUGINS_DIR)
 	cp -vi bin/starboard-octant-plugin $(OCTANT_PLUGINS_DIR)
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ You must have a working Go environment.
 ```
 $ git clone git@github.com:aquasecurity/starboard-octant-plugin.git
 $ cd starboard-octant-plugin
-$ make deploy
+$ make install
 ```
 
-The `make deploy` goal copies the plugin binary to the `$HOME/.config/octant/plugins` directory.
+The `make install` goal copies the plugin binary to the `$HOME/.config/octant/plugins` directory.
 
 ## Getting Started
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/aquasecurity/starboard-octant-plugin
 go 1.14
 
 require (
-	github.com/aquasecurity/starboard v0.4.1-0.20200923101908-ca60574a118f
+	github.com/aquasecurity/starboard v0.4.1-0.20200925135657-c725493e4177
 	github.com/stretchr/testify v1.6.1
 	github.com/vmware-tanzu/octant v0.15.0
+	k8s.io/apiextensions-apiserver v0.19.0-alpha.3
 	k8s.io/apimachinery v0.19.0-beta.2
 )

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
-github.com/aquasecurity/starboard v0.4.1-0.20200923101908-ca60574a118f h1:rrdkeHqSnE6z/og/Pse54kKnMF1l/bD6SJVlRIPlIKI=
-github.com/aquasecurity/starboard v0.4.1-0.20200923101908-ca60574a118f/go.mod h1:Xdodbl8+u6Na3ah5DoeBONtVavbCrwMA7CcpKYDBizo=
+github.com/aquasecurity/starboard v0.4.1-0.20200925135657-c725493e4177 h1:JlX6m/HaX/14zWYsTT/Q2Qv7Loo4s99/LXT7VHVtMx4=
+github.com/aquasecurity/starboard v0.4.1-0.20200925135657-c725493e4177/go.mod h1:Xdodbl8+u6Na3ah5DoeBONtVavbCrwMA7CcpKYDBizo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/pkg/plugin/controller/root.go
+++ b/pkg/plugin/controller/root.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/aquasecurity/starboard-octant-plugin/pkg/plugin/view/kubehunter"
 
 	"github.com/aquasecurity/starboard-octant-plugin/pkg/plugin/model"

--- a/pkg/plugin/model/repository.go
+++ b/pkg/plugin/model/repository.go
@@ -7,12 +7,12 @@ import (
 	"sort"
 	"strings"
 
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	"github.com/aquasecurity/starboard/pkg/apis/aquasecurity"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/aquasecurity/starboard/pkg/kube"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	starboard "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/vmware-tanzu/octant/pkg/plugin/service"
@@ -33,15 +33,17 @@ func NewRepository(client service.Dashboard) *Repository {
 	}
 }
 
-type ContainerImageScanReport struct {
+// NamedVulnerabilityReport allows sorting VulnerabilityReports by container name.
+type NamedVulnerabilityReport struct {
 	Name   string
 	Report starboard.VulnerabilityReport
 }
 
-func (r *Repository) GetVulnerabilitiesSummary(ctx context.Context, options kube.Object) (vs starboard.VulnerabilitySummary, err error) {
-	containerReports, err := r.GetVulnerabilitiesForWorkload(ctx, options)
+func (r *Repository) GetVulnerabilitiesSummary(ctx context.Context, options kube.Object) (*starboard.VulnerabilitySummary, error) {
+	vs := &starboard.VulnerabilitySummary{}
+	containerReports, err := r.GetVulnerabilityReportsByOwner(ctx, options)
 	if err != nil {
-		return vs, err
+		return nil, err
 	}
 	for _, cr := range containerReports {
 		for _, v := range cr.Report.Report.Vulnerabilities {
@@ -59,17 +61,31 @@ func (r *Repository) GetVulnerabilitiesSummary(ctx context.Context, options kube
 			}
 		}
 	}
-	return
+	return vs, nil
 }
 
-func (r *Repository) GetVulnerabilitiesForWorkload(ctx context.Context, options kube.Object) (reports []ContainerImageScanReport, err error) {
+func (r *Repository) GetCustomResourceDefinitionByName(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
+	unstructuredResp, err := r.client.Get(ctx, store.Key{
+		APIVersion: fmt.Sprintf("%s/%s", "apiextensions.k8s.io", "v1beta1"),
+		Kind:       "CustomResourceDefinition",
+		Name:       name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var crd v1.CustomResourceDefinition
+	err = r.structure(unstructuredResp, &crd)
+	return &crd, err
+}
+
+func (r *Repository) GetVulnerabilityReportsByOwner(ctx context.Context, owner kube.Object) (reports []NamedVulnerabilityReport, err error) {
 	unstructuredList, err := r.client.List(ctx, store.Key{
 		APIVersion: fmt.Sprintf("%s/%s", aquasecurity.GroupName, starboard.VulnerabilityReportsCRVersion),
 		Kind:       starboard.VulnerabilityReportKind,
-		Namespace:  options.Namespace,
+		Namespace:  owner.Namespace,
 		Selector: &labels.Set{
-			kube.LabelResourceKind: string(options.Kind),
-			kube.LabelResourceName: options.Name,
+			kube.LabelResourceKind: string(owner.Kind),
+			kube.LabelResourceName: owner.Name,
 		},
 	})
 	if err != nil {
@@ -84,8 +100,8 @@ func (r *Repository) GetVulnerabilitiesForWorkload(ctx context.Context, options 
 	}
 	for _, item := range reportList.Items {
 		if containerName, containerNameSpecified := item.Labels[kube.LabelContainerName]; containerNameSpecified {
-			reports = append(reports, ContainerImageScanReport{
-				Name:   fmt.Sprintf("Container %s", containerName),
+			reports = append(reports, NamedVulnerabilityReport{
+				Name:   containerName,
 				Report: *item.DeepCopy(),
 			})
 		}
@@ -98,14 +114,15 @@ func (r *Repository) GetVulnerabilitiesForWorkload(ctx context.Context, options 
 	return
 }
 
-func (r *Repository) GetConfigAudit(ctx context.Context, options kube.Object) (report *starboard.ConfigAuditReport, err error) {
+func (r *Repository) GetConfigAuditReport(ctx context.Context, owner kube.Object) (report *starboard.ConfigAuditReport, err error) {
 	unstructuredList, err := r.client.List(ctx, store.Key{
 		APIVersion: fmt.Sprintf("%s/%s", aquasecurity.GroupName, starboard.ConfigAuditReportCRVersion),
 		Kind:       starboard.ConfigAuditReportKind,
-		Namespace:  options.Namespace,
+		Namespace:  owner.Namespace,
 		Selector: &labels.Set{
-			kube.LabelResourceKind: string(options.Kind),
-			kube.LabelResourceName: options.Name,
+			kube.LabelResourceKind:      string(owner.Kind),
+			kube.LabelResourceName:      owner.Name,
+			kube.LabelResourceNamespace: owner.Namespace,
 		},
 	})
 	if err != nil {
@@ -178,8 +195,8 @@ func (r *Repository) GetKubeHunterReport(ctx context.Context) (report *starboard
 	return
 }
 
-func (r *Repository) structure(ul *unstructured.UnstructuredList, v interface{}) (err error) {
-	b, err := ul.MarshalJSON()
+func (r *Repository) structure(m json.Marshaler, v interface{}) (err error) {
+	b, err := m.MarshalJSON()
 	if err != nil {
 		return
 	}

--- a/pkg/plugin/model/repository.go
+++ b/pkg/plugin/model/repository.go
@@ -66,7 +66,7 @@ func (r *Repository) GetVulnerabilitiesSummary(ctx context.Context, options kube
 
 func (r *Repository) GetCustomResourceDefinitionByName(ctx context.Context, name string) (*v1.CustomResourceDefinition, error) {
 	unstructuredResp, err := r.client.Get(ctx, store.Key{
-		APIVersion: fmt.Sprintf("%s/%s", "apiextensions.k8s.io", "v1beta1"),
+		APIVersion: "apiextensions.k8s.io/v1beta1",
 		Kind:       "CustomResourceDefinition",
 		Name:       name,
 	})

--- a/pkg/plugin/view/configaudit/report_view.go
+++ b/pkg/plugin/view/configaudit/report_view.go
@@ -29,7 +29,7 @@ func NewReport(workload kube.Object, configAuditReportsDefined bool, report *sta
 				Width: component.WidthFull,
 				View: component.NewMarkdownText(fmt.Sprintf(
 					"The `%[1]s` resource, which represents config audit reports, is not defined.\n"+
-						"> You can define such resource by running the [Starboard CLI][starboard-cli] init command:\n"+
+						"> You can create this resource definition by running the [Starboard CLI][starboard-cli] init command:\n"+
 						"> ```\n"+
 						"> $ kubectl starboard init\n"+
 						"> ```\n"+

--- a/pkg/plugin/view/configaudit/report_view.go
+++ b/pkg/plugin/view/configaudit/report_view.go
@@ -28,7 +28,7 @@ func NewReport(workload kube.Object, configAuditReportsDefined bool, report *sta
 			{
 				Width: component.WidthFull,
 				View: component.NewMarkdownText(fmt.Sprintf(
-					"The `%[1]s` resource, which represents config audit reports is not defined.\n"+
+					"The `%[1]s` resource, which represents config audit reports, is not defined.\n"+
 						"> You can define such resource by running the [Starboard CLI][starboard-cli] init command:\n"+
 						"> ```\n"+
 						"> $ kubectl starboard init\n"+

--- a/pkg/plugin/view/vulnerabilities/report_view.go
+++ b/pkg/plugin/view/vulnerabilities/report_view.go
@@ -25,7 +25,7 @@ func NewReport(workload kube.Object, vulnerabilityReportsDefined bool, reports [
 			{
 				Width: component.WidthFull,
 				View: component.NewMarkdownText(fmt.Sprintf(
-					"The `%[1]s` resource, which represents vulnerability reports is not defined.\n"+
+					"The `%[1]s` resource, which represents vulnerability reports, is not defined.\n"+
 						"> You can define such resource by running the [Starboard CLI][starboard-cli] init command:\n"+
 						"> ```\n"+
 						"> $ kubectl starboard init\n"+

--- a/pkg/plugin/view/vulnerabilities/report_view.go
+++ b/pkg/plugin/view/vulnerabilities/report_view.go
@@ -26,7 +26,7 @@ func NewReport(workload kube.Object, vulnerabilityReportsDefined bool, reports [
 				Width: component.WidthFull,
 				View: component.NewMarkdownText(fmt.Sprintf(
 					"The `%[1]s` resource, which represents vulnerability reports, is not defined.\n"+
-						"> You can define such resource by running the [Starboard CLI][starboard-cli] init command:\n"+
+						"> You can create this resource definition by running the [Starboard CLI][starboard-cli] init command:\n"+
 						"> ```\n"+
 						"> $ kubectl starboard init\n"+
 						"> ```\n"+

--- a/pkg/plugin/view/vulnerabilities/summary_sections_view.go
+++ b/pkg/plugin/view/vulnerabilities/summary_sections_view.go
@@ -7,7 +7,10 @@ import (
 	"github.com/vmware-tanzu/octant/pkg/view/component"
 )
 
-func NewSummarySections(summary security.VulnerabilitySummary) []component.SummarySection {
+func NewSummarySections(summary *security.VulnerabilitySummary) []component.SummarySection {
+	if summary == nil {
+		return []component.SummarySection{}
+	}
 	return []component.SummarySection{
 		{Header: "Critical Vulnerabilities", Content: component.NewText(strconv.Itoa(summary.CriticalCount))},
 		{Header: "High Vulnerabilities", Content: component.NewText(strconv.Itoa(summary.HighCount))},


### PR DESCRIPTION
We assumed that the `starboard init` command was run before sb installed the plugin. However, this might not be the case. If `vulnerabilityreports` and `configauditreports` custom resources are not defined the Octant UI pops up some ugly RPC errors.
In this PR I introduced checks to see if CRD are present, and only then fetch the data. The plugin UI components also give some hints in case the CRD are undefined.

![vulnerabilityreports_crd_undefined](https://user-images.githubusercontent.com/1322923/94812042-797ceb00-03f6-11eb-8811-eb0b9b10e78a.png)

![configauditreports_crd_undefined](https://user-images.githubusercontent.com/1322923/94812071-8568ad00-03f6-11eb-9662-77eb87f6dc44.png)

Resolves: #60

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>