### PR TITLE
feat: Display VulnerabilityReports owned by ReplicaSet for corresponding Deployment and Pods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aquasecurity/starboard v0.4.1-0.20200925135657-c725493e4177
 	github.com/stretchr/testify v1.6.1
 	github.com/vmware-tanzu/octant v0.15.0
+	k8s.io/api v0.19.0-alpha.3
 	k8s.io/apiextensions-apiserver v0.19.0-alpha.3
 	k8s.io/apimachinery v0.19.0-beta.2
 )

--- a/pkg/plugin/view/configaudit/report_view.go
+++ b/pkg/plugin/view/configaudit/report_view.go
@@ -73,7 +73,7 @@ func NewReport(workload kube.Object, configAuditReportsDefined bool, report *sta
 	flexLayout.AddSections(component.FlexLayoutSection{
 		{
 			Width: component.WidthThird,
-			View:  view.NewReportSummary(report.GetCreationTimestamp().Time),
+			View:  view.NewReportMetadata(report.ObjectMeta),
 		},
 		{
 			Width: component.WidthThird,

--- a/pkg/plugin/view/kubebench/report_view.go
+++ b/pkg/plugin/view/kubebench/report_view.go
@@ -67,7 +67,7 @@ func NewReport(kubeBenchReportsDefined bool, report *starboard.CISKubeBenchRepor
 	uiSections = append([]component.FlexLayoutItem{
 		{
 			Width: component.WidthThird,
-			View:  view.NewReportSummary(report.CreationTimestamp.Time),
+			View:  view.NewReportMetadata(report.ObjectMeta),
 		},
 		{
 			Width: component.WidthThird,

--- a/pkg/plugin/view/kubehunter/report_view.go
+++ b/pkg/plugin/view/kubehunter/report_view.go
@@ -57,7 +57,7 @@ func NewReport(kubeHunterReportsDefined bool, report *starboard.KubeHunterReport
 	flexLayout.AddSections(component.FlexLayoutSection{
 		{
 			Width: component.WidthThird,
-			View:  view.NewReportSummary(report.CreationTimestamp.Time),
+			View:  view.NewReportMetadata(report.ObjectMeta),
 		},
 		{
 			Width: component.WidthThird,

--- a/pkg/plugin/view/scanner_summary.go
+++ b/pkg/plugin/view/scanner_summary.go
@@ -1,10 +1,9 @@
 package view
 
 import (
-	"time"
-
 	sec "github.com/aquasecurity/starboard/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/vmware-tanzu/octant/pkg/view/component"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewScannerSummary(scanner sec.Scanner) (c *component.Summary) {
@@ -27,14 +26,18 @@ func NewScannerSummary(scanner sec.Scanner) (c *component.Summary) {
 	return
 }
 
-// TODO Accept ObjectMeta to display other info such as labels
-func NewReportSummary(generatedAt time.Time) (c *component.Summary) {
-	c = component.NewSummary("Report Metadata")
+func NewReportMetadata(meta metav1.ObjectMeta) (c *component.Summary) {
+	c = component.NewSummary("Metadata")
 	sections := []component.SummarySection{
 		{
-			Header:  "Generated At",
-			Content: component.NewTimestamp(generatedAt),
+			Header:  "Age",
+			Content: component.NewTimestamp(meta.CreationTimestamp.Time),
 		},
+		{
+			Header:  "Labels",
+			Content: component.NewLabels(meta.Labels),
+		},
+		// TODO Add link to the Owner
 	}
 	c.Add(sections...)
 	return

--- a/pkg/plugin/view/vulnerabilities/report_view.go
+++ b/pkg/plugin/view/vulnerabilities/report_view.go
@@ -68,25 +68,27 @@ func NewReport(workload kube.Object, vulnerabilityReportsDefined bool, reports [
 	}
 
 	var items []component.FlexLayoutItem
-	for _, containerReport := range reports {
+	for _, namedReport := range reports {
+		report := namedReport.Report
+		result := report.Report
 		items = append(items, component.FlexLayoutItem{
 			Width: component.WidthThird,
-			View:  view.NewReportMetadata(containerReport.Report.ObjectMeta),
+			View:  view.NewReportMetadata(report.ObjectMeta),
 		})
 
 		items = append(items, component.FlexLayoutItem{
 			Width: component.WidthThird,
-			View:  view.NewScannerSummary(containerReport.Report.Report.Scanner),
+			View:  view.NewScannerSummary(result.Scanner),
 		})
 
 		items = append(items, component.FlexLayoutItem{
 			Width: component.WidthThird,
-			View:  NewVulnerabilitiesSummary("Summary", containerReport.Report.Report.Summary),
+			View:  NewVulnerabilitiesSummary("Summary", result.Summary),
 		})
 
 		items = append(items, component.FlexLayoutItem{
 			Width: component.WidthFull,
-			View:  createVulnerabilitiesTable(containerReport.Name, containerReport.Report.Report),
+			View:  createVulnerabilitiesTable(namedReport.Name, result),
 		})
 	}
 


### PR DESCRIPTION
It's reasonable to associate vulnerability reports with a ReplicaSet controlled by a Deployment rather than storing them at the Deployment level or Pod level. Duplicating instances of VulnerabilityReports resources also doesn't make sense and complicates manual/automated reconciliation process in terms of consistency.

In this PR I added some "intelligence" to lookup vulnerability reports based on Kubernetes objects hierarchy.

For example, even if the VulnerabilityReport is owned by ReplicaSet/nginx-6d4cf56db6, it is also displayed at the Deployment/nginx level as well as for each pod, i.e. Pod/nginx-6d4cf56db6-b85l6, Pod/nginx-6d4cf56db6-czsb8, and Pod/nginx-6d4cf56db6-gxdv6:

```
$ kubectl tree deploy nginx
NAMESPACE  NAME                                                          READY  REASON  AGE
default    Deployment/nginx                                              -              4h24m
default    └─ReplicaSet/nginx-6d4cf56db6                                 -              4h24m
default      ├─Pod/nginx-6d4cf56db6-b85l6                                True           4h22m
default      ├─Pod/nginx-6d4cf56db6-czsb8                                True           4h22m
default      ├─Pod/nginx-6d4cf56db6-gxdv6                                True           4h24m
default      └─VulnerabilityReport/cdade47d-781f-4b2b-9f70-4af2481a1af6  -              4h14m
```

Before this change was implemented, we would only see the vulnerability report for the selected ReplicaSet:

![vulns_for_replicaset](https://user-images.githubusercontent.com/1322923/94929857-ed39f900-04c5-11eb-9940-7f739c06f104.png)

And now, we can also access the same report by selecting Deployment or Pods:

![vulns_for_deployment](https://user-images.githubusercontent.com/1322923/94930003-165a8980-04c6-11eb-9e76-baa750c4d0d4.png)

![vulns_for_pod](https://user-images.githubusercontent.com/1322923/94930025-1ce90100-04c6-11eb-88a8-3a707936bf30.png)

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>